### PR TITLE
list-hashtag-bug-fix

### DIFF
--- a/frontend/src/components/Common/ListCard.js
+++ b/frontend/src/components/Common/ListCard.js
@@ -56,6 +56,7 @@ const ListCard = ({ data, index, type, toggleScrap }) => {
     };
 
     const checkHoneyStatus = async () => {
+      if (!user) return;
       try {
         const response = await axios.get(
           `http://localhost:5001/api/projects/${data.id}/honey/${user.id}`
@@ -66,11 +67,9 @@ const ListCard = ({ data, index, type, toggleScrap }) => {
       }
     };
 
-    if (user) {
-      fetchHashtags();
-      fetchParticipants();
-      checkHoneyStatus();
-    }
+    fetchHashtags();
+    fetchParticipants();
+    checkHoneyStatus();
 
     return () => {
       isMounted = false;
@@ -89,6 +88,10 @@ const ListCard = ({ data, index, type, toggleScrap }) => {
 
   const handleHoneyClick = async e => {
     e.stopPropagation();
+    if (!user) {
+      console.error("User is not authenticated");
+      return;
+    }
     try {
       if (isHoney) {
         await axios.delete(


### PR DESCRIPTION
## 📌제목 : 목록 페이지에서 비로그인 상태일 시 해시태그가 안보이는 버그 수정

### ➡️PR 방향

- [ ] 버그 -> 버그 스크린 샷 첨부 요망
- [ ] 수정 -> 원본, 바뀐 부분 첨부, 설명 요망
- [ ] 초기(첫 푸시) -> 첫 푸시 내용 설명 요망
- [ ] 요청 -> 요청 부분 설명 요망

### 📝내용

- 목록 페이지에서 비로그인 상태일 시 해시태그가 안보이는 버그 수정
- 비 로그인 상태에서 꿀단지 버튼(스크랩) 클릭 시 콘솔에 오류 메시지 표시(임시)
