### PR TITLE
feat: 목록 페이지 타이틀 표시 (#219)

### DIFF
--- a/frontend/src/components/Layout/ProjectListPageLayout.js
+++ b/frontend/src/components/Layout/ProjectListPageLayout.js
@@ -15,11 +15,14 @@ const ProjectListPageLayout = () => {
   const [activePage, setActivePage] = useState(1);
   const [filterItem, setFilterItem] = useState(false);
   const location = useLocation();
+  const [title, setTitle] = useState("전체");
 
   useEffect(() => {
     const fetchProjects = async () => {
       try {
         const query = new URLSearchParams(location.search).get("query");
+        // 검색어 입력했을 때 결과를 보여줍니다.
+        setTitle(`${query} 검색결과`);
         const response = query
           ? await axios.get(
               `http://localhost:5001/api/projects/search?query=${query}`
@@ -48,6 +51,23 @@ const ProjectListPageLayout = () => {
     setSortedCardList(copyCardList);
   }, [sortBtn, cards, filterItem]);
 
+  useEffect(() => {
+    switch (filterItem) {
+      case "with": {
+        setTitle("버디비_동행");
+        break;
+      }
+      case "funding": {
+        setTitle("버디비_펀딩");
+        break;
+      }
+      default: {
+        setTitle("전체");
+        break;
+      }
+    }
+  }, [filterItem]);
+
   const toggleScrap = (index, type) => {
     const updatedCards = [...sortedCardList];
     updatedCards[index].scrap = !updatedCards[index].scrap;
@@ -59,7 +79,7 @@ const ProjectListPageLayout = () => {
   const indexOfFirstItem = indexOfLastItem - itemsCountPerPage;
   const currentItems = sortedCardList.slice(indexOfFirstItem, indexOfLastItem);
 
-  const handlePageChange = pageNumber => {
+  const handlePageChange = (pageNumber) => {
     setActivePage(pageNumber);
   };
 
@@ -70,7 +90,7 @@ const ProjectListPageLayout = () => {
         <PageLayout>
           <div className="project-list-page-layout-wrapper">
             <div className="project-list-page-layout-line1">
-              <h1>#동행 모집</h1>
+              <h1>#{title}</h1>
               <div className="project-list-btn-wrapper">
                 <button
                   className={`sort-latest ${
@@ -103,7 +123,7 @@ const ProjectListPageLayout = () => {
                   ))
                 : filterItem === "with"
                 ? currentItems
-                    .filter(item => item.type === "with")
+                    .filter((item) => item.type === "with")
                     .map((data, index) => (
                       <ListCard
                         key={index}
@@ -115,7 +135,7 @@ const ProjectListPageLayout = () => {
                     ))
                 : filterItem === "funding"
                 ? currentItems
-                    .filter(item => item.type === "funding")
+                    .filter((item) => item.type === "funding")
                     .map((data, index) => (
                       <ListCard
                         key={index}


### PR DESCRIPTION
## 📌 feat : 목록 페이지 타이틀 표시 (#219)

### ➡️PR 방향

- [ ] 버그 -> 버그 스크린 샷 첨부 요망
- [ ] 수정 -> 원본, 바뀐 부분 첨부, 설명 요망
- [x] 초기(첫 푸시) -> 첫 푸시 내용 설명 요망
- [ ] 요청 -> 요청 부분 설명 요망

### 📝내용

- subnav 에 있는 메뉴 눌렀을 시 이동 및 표시
- 검색어 쳤을 시 타이틀에 표시

---

#### ⛓️연결된 이슈 :

Fixes #219 
