### PR TITLE
Header 모바일 뷰 높이 변경_css fix/header mobile height

### DIFF
--- a/frontend/src/components/Header/Header.css
+++ b/frontend/src/components/Header/Header.css
@@ -1,6 +1,11 @@
 @import "../../styles/mixins.css";
 @import "../../styles/variables.css";
 
+/* 페이지 컨텐츠의 맨 위에 패딩 추가 */
+body {
+  padding-top: 88px; /* 헤더의 높이와 동일하게 설정 */
+}
+
 .headerpage-header {
   display: flex;
   flex-direction: row;
@@ -205,11 +210,6 @@
   background-color: #f0f0f0;
 }
 
-/* 페이지 컨텐츠의 맨 위에 패딩 추가 */
-body {
-  padding-top: 88px; /* 헤더의 높이와 동일하게 설정 */
-}
-
 /* 햄버거 버튼 아이콘 */
 .headerpage-hamburger-icon {
   display: none;
@@ -223,11 +223,11 @@ body {
 .icon-1,
 .icon-2,
 .icon-3 {
-  top: 43px;
+  top: 28px;
   position: absolute;
   width: 35px;
   height: 2.5px;
-  right: 11vw;
+  right: 7vw;
   background-color: black;
   transition: all 0.2s cubic-bezier(0.84, 0.06, 0.52, 1.8);
 }
@@ -266,14 +266,14 @@ body {
   z-index: -1;
   opacity: 1;
   transition: 1s ease;
-  margin-top: 92px;
+  margin-top: 60px;
 }
 
 /* 햄버거 버튼 전체 드롭다운 */
 .headerpage-hamburger-dropdown {
   position: absolute;
-  top: 100px;
-  right: 9vw;
+  top: 110%;
+  right: 5vw;
   visibility: hidden;
   display: flex;
   z-index: 9999;
@@ -393,7 +393,6 @@ body {
 .hamburger-dropdown-menu {
   top: 55px;
   right: 60px;
-
   margin-bottom: 5px;
 }
 
@@ -487,11 +486,24 @@ body {
     display: none; /*기존 요소 가리기*/
   }
 
+  body {
+    padding-top: 60px; /* 헤더의 높이와 동일하게 변경 */
+  }
+
   .headerpage-header-container {
-    padding: 10px 2vw;
+    padding: 5px 1vw;
+  }
+
+  .headerpage-header {
+    padding: 0;
+  }
+  .headerpage-header-icon {
+    width: 43px;
+    height: 43px;
   }
 
   .headerpage-hamburger-icon {
+    /*햄버거 버튼 표시*/
     display: block;
   }
 }

--- a/frontend/src/components/Header/Header.js
+++ b/frontend/src/components/Header/Header.js
@@ -127,7 +127,7 @@ const Header = () => {
       <div className="headerpage-header-container">
         <div className="headerpage-header-left">
           <Link to="/">
-            <img src={icon} alt="Icon" />
+            <img src={icon} className="headerpage-header-icon" alt="Icon" />
           </Link>
           <Link to="/">
             <h1 className="headerpage-header-logo">BUDDY BEE</h1>


### PR DESCRIPTION
## 📌제목 : Header 모바일 뷰 높이 변경_css fix/header mobile height

### ➡️PR 방향

- [ ] 버그 -> 버그 스크린 샷 첨부 요망
- [x] 수정 -> 원본, 바뀐 부분 첨부, 설명 요망
- [ ] 초기(첫 푸시) -> 첫 푸시 내용 설명 요망
- [ ] 요청 -> 요청 부분 설명 요망

### 📝내용

- width 479px 이하인 경우 Header height 60으로 조정(네이버 모바일 참고함)

#### ⛓️연결된 이슈 :

Fixes #287 
