### PR TITLE
펀딩 글 작성 페이지 모바일 뷰_feature/322 create funding mobile view

### DIFF
--- a/frontend/src/components/Layout/CreatePageLayout.css
+++ b/frontend/src/components/Layout/CreatePageLayout.css
@@ -444,6 +444,20 @@
   white-space: nowrap;
   font-size: 15px;
 }
+/*모바일용*/
+.mobile-createpage-edit-button {
+  padding: 9px 12px;
+  background-color: #000;
+  color: #fff;
+  border: none;
+  cursor: pointer;
+  border-radius: 50px;
+  font-weight: 400;
+  white-space: nowrap;
+  font-size: 14px;
+
+  display: none;
+}
 .ck.ck-editor__editable_inline {
   height: 600px;
 }
@@ -496,15 +510,19 @@
 
 @media (max-width: 479px) {
   /* 기존 요소 중 블락 처리한 것들 */
-  .createpage-add-button {
+  .createpage-add-button,
+  .createpage-edit-button {
     display: none;
   }
   #option-add {
     margin-right: 10px;
   }
+  .mobile-createpage-add-button,
+  .mobile-createpage-edit-button {
+    display: inline-block;
+  }
   .mobile-createpage-add-button {
     margin-right: 10px;
-    display: inline-block;
   }
 
   .createpage-create-project-form {
@@ -573,7 +591,9 @@
     font-weight: 400;
     margin-right: 6px;
   }
-
+  .createpage-account-input-wrapper input {
+    padding: 0 0 0 8px;
+  }
   .createpage-option-form-group {
     border: 1px dotted black;
     display: flex;
@@ -631,9 +651,6 @@
     border: none;
     cursor: pointer;
     font-size: 12px;
-    /* padding: 0 5px; */
-    /* font-weight: 600; */
-    /* white-space: nowrap; */
   }
 
   .createpage-edit-button {
@@ -654,6 +671,11 @@
     font-size: 1rem;
     padding: 20px 80px;
     border: 1px solid black;
+  }
+
+  /*펀딩 전용 항목들*/
+  .createpage-account-input-wrapper input {
+    font-size: 14px;
   }
 }
 @media (max-width: 404px) {

--- a/frontend/src/components/Layout/CreatePageLayout.css
+++ b/frontend/src/components/Layout/CreatePageLayout.css
@@ -249,18 +249,28 @@
   padding: 20px 30px 20px 20px;
   border-radius: 15px;
   display: flex;
-  flex-direction: column;
   gap: 10px;
 }
 .createpage-recruitment-group span {
   white-space: nowrap;
 }
+/*요기*/
 .createpage-recruitment-input-wrapper {
   display: flex;
-  align-items: center;
-  gap: 20px;
+  justify-content: space-between;
+  gap: 10px;
 }
 
+.createpage-recruitment-people-input,
+.createpage-recruitment-amount-input {
+  display: flex;
+  width: 100%;
+  align-items: center;
+  gap: 10px;
+}
+.createpage-recruitment-people-input {
+  margin-right: 20px;
+}
 .createpage-number-input {
   flex: 1;
   display: flex;
@@ -524,12 +534,14 @@
   .mobile-createpage-add-button {
     margin-right: 10px;
   }
-
   .createpage-create-project-form {
     display: flex;
     flex-direction: column;
     gap: 20px;
     width: 100%;
+  }
+  .whitespace-nowrap {
+    margin: 0px;
   }
   .createpage-create-main-section {
     padding: 0 5.5% 120px 5.5%;
@@ -608,8 +620,16 @@
     padding: 10px 16px 12px 12px;
   }
   .createpage-recruitment-input-wrapper {
+    flex-direction: column;
     gap: 5px;
   }
+
+  .createpage-option {
+    padding: 5px;
+    width: 87%;
+    margin-left: 0px;
+  }
+
   /* ck editor 스타일 조절 */
   .ck.ck-editor__editable_inline {
     height: 300px;

--- a/frontend/src/components/Layout/CreatePageLayout.css
+++ b/frontend/src/components/Layout/CreatePageLayout.css
@@ -481,6 +481,13 @@
     font-size: 1.2rem;
     padding: 20px 90px;
   }
+  .createpage-form-group label {
+    font-weight: 1000;
+    font-size: 22px;
+  }
+  .createpage-hashtag-limit {
+    font-size: 15px;
+  }
 }
 
 @media (min-width: 480px) and (max-width: 767px) {
@@ -510,6 +517,13 @@
 
   .createpage-title-input {
     margin-top: 20px;
+  }
+  .createpage-form-group label {
+    font-weight: 1000;
+    font-size: 20px;
+  }
+  .createpage-hashtag-limit {
+    font-size: 15px;
   }
   .createpage-submit-button {
     font-weight: 500;

--- a/frontend/src/components/Layout/CreatePageLayout.js
+++ b/frontend/src/components/Layout/CreatePageLayout.js
@@ -225,21 +225,40 @@ const CreatePageLayout = ({ children, type }) => {
                       className={isEditingAccount ? "editable" : ""}
                     />
                     {isEditingAccount ? (
-                      <button
-                        type="button"
-                        onClick={handleAccountSave}
-                        className="createpage-edit-button"
-                      >
-                        저장하기
-                      </button>
+                      <>
+                        <button
+                          type="button"
+                          onClick={handleAccountSave}
+                          className="createpage-edit-button"
+                        >
+                          저장하기
+                        </button>
+                        {/* 모바일 전용 버튼 분리 */}
+                        <button
+                          type="button"
+                          onClick={handleAccountSave}
+                          className="mobile-createpage-edit-button"
+                        >
+                          저장
+                        </button>
+                      </>
                     ) : (
-                      <button
-                        type="button"
-                        onClick={handleAccountEdit}
-                        className="createpage-edit-button"
-                      >
-                        수정하기
-                      </button>
+                      <>
+                        <button
+                          type="button"
+                          onClick={handleAccountEdit}
+                          className="createpage-edit-button"
+                        >
+                          수정하기
+                        </button>
+                        <button
+                          type="button"
+                          onClick={handleAccountEdit}
+                          className="mobile-createpage-edit-button"
+                        >
+                          수정
+                        </button>
+                      </>
                     )}
                   </div>
                 </div>

--- a/frontend/src/components/Layout/CreatePageLayout.js
+++ b/frontend/src/components/Layout/CreatePageLayout.js
@@ -332,22 +332,24 @@ const CreatePageLayout = ({ children, type }) => {
                 </label>
                 <div className="createpage-form-group createpage-recruitment-group">
                   <div className="createpage-recruitment-input-wrapper">
-                    <span>모집 인원</span>
-                    <div className="createpage-project-setting-group">
-                      <div className="createpage-number-input">
-                        <input
-                          type="number"
-                          min={1}
-                          value={maxParticipants}
-                          onChange={e => setMaxParticipants(e.target.value)}
-                          placeholder="모집 인원"
-                        />
+                    <div className="createpage-recruitment-people-input">
+                      <span>모집 인원</span>
+                      <div className="createpage-project-setting-group">
+                        <div className="createpage-number-input">
+                          <input
+                            type="number"
+                            min={1}
+                            value={maxParticipants}
+                            onChange={e => setMaxParticipants(e.target.value)}
+                            placeholder="모집 인원"
+                          />
+                        </div>
+                        <span>명</span>
                       </div>
-                      <span>명</span>
                     </div>
 
                     {type === "funding" && (
-                      <>
+                      <div className="createpage-recruitment-amount-input">
                         <span className="whitespace-nowrap">목표 금액</span>
                         <div className="createpage-project-setting-group">
                           <div className="createpage-number-input">
@@ -360,7 +362,7 @@ const CreatePageLayout = ({ children, type }) => {
                           </div>
                           <span>원</span>
                         </div>
-                      </>
+                      </div>
                     )}
                   </div>
                 </div>


### PR DESCRIPTION
## 📌제목 : 펀딩 글 작성 페이지 모바일 뷰

### ➡️PR 방향

- [ ] 버그 -> 버그 스크린 샷 첨부 요망
- [x] 수정 -> 원본, 바뀐 부분 첨부, 설명 요망
- [ ] 초기(첫 푸시) -> 첫 푸시 내용 설명 요망
- [ ] 요청 -> 요청 부분 설명 요망

### 📝내용
js
- 펀딩 글 작성 페이지 createpage-recruitment-group쪽 **구조 변경** 
- (**기존** : 한 div안에 모집 인원,모집 금액 span,input 포함  => **변경 후** : 모집 인원/모집 금액에 각각 div 씌움)


- 수정/저장 버튼 모바일 전용으로 하나 더 생성/query로 block,none 스위치

css
- 모바일 뷰 스타일 변경

---

#### ⛓️연결된 이슈 :

Fixes #322 
