### PR TITLE
fix: CreatePage and ProjectPage (#486)

### DIFF
--- a/frontend/src/components/Layout/CreatePageLayout.css
+++ b/frontend/src/components/Layout/CreatePageLayout.css
@@ -72,7 +72,7 @@
   padding: 10px 2px;
   border-bottom: 1px solid black;
   font-size: 18px;
-  margin-top: 50px;
+  margin-top: 10px;
 }
 
 .createpage-title-input::placeholder {
@@ -88,7 +88,7 @@
   display: flex;
   flex-direction: column;
   gap: 10px;
-  margin-bottom: 25px;
+  margin-bottom: 3px;
 }
 
 .createpage-hashtag-limit {

--- a/frontend/src/components/Layout/CreatePageLayout.js
+++ b/frontend/src/components/Layout/CreatePageLayout.js
@@ -148,14 +148,27 @@ const CreatePageLayout = ({ children, type: initialType }) => {
   };
 
   const addHashtag = () => {
-    if (
-      hashtag.trim() &&
-      !hashtags.includes(hashtag) &&
-      hashtag.length <= 15 &&
-      hashtags.length < 10
-    ) {
+    if (hashtags.length >= 10) {
+      Swal.fire({
+        title: "Error",
+        text: "해시태그는 최대 10개까지 등록이 가능합니다!",
+        icon: "warning",
+        confirmButtonText: "확인",
+      });
+      return;
+    }
+
+    if (hashtag.trim() && !hashtags.includes(hashtag) && hashtag.length <= 15) {
       setHashtags([...hashtags, hashtag.trim()]);
       setHashtag("");
+    }
+  };
+
+  //해시태그 - 띄어쓰기 제한
+  const handleHashtagChange = (e) => {
+    const newHashtag = e.target.value;
+    if (!newHashtag.includes(" ")) {
+      setHashtag(newHashtag);
     }
   };
 
@@ -170,8 +183,28 @@ const CreatePageLayout = ({ children, type: initialType }) => {
         (option) => option.name === optionName.trim()
       );
       const isSameAsDeleted = optionName.trim() === deleteOptionName;
+
+      if (options.length >= 10) {
+        Swal.fire({
+          title: "Error",
+          text: "최대 10개까지만 추가할 수 있습니다.",
+          icon: "warning",
+          confirmButtonText: "확인",
+        });
+        return;
+      }
+
       // 중복이 아니라면 추가
       if (!isDuplicate || isSameAsDeleted) {
+        if (type === "funding" && !optionPrice.trim()) {
+          Swal.fire({
+            title: "Error",
+            text: "펀딩 옵션의 가격을 입력해 주세요.",
+            icon: "error",
+            confirmButtonText: "확인",
+          });
+          return;
+        }
         setOptions([
           ...options,
           {
@@ -250,7 +283,12 @@ const CreatePageLayout = ({ children, type: initialType }) => {
     if (desc.length <= 3000) {
       setContent(desc);
     } else {
-      alert("3000자 이상은 작성할 수 없습니다.");
+      Swal.fire({
+        title: "Error",
+        text: "3000자 이상은 작성할 수 없습니다.",
+        icon: "warning",
+        confirmButtonText: "확인",
+      });
       setContent(desc.slice(0, 3000));
     }
   };
@@ -304,6 +342,9 @@ const CreatePageLayout = ({ children, type: initialType }) => {
         </div>
         <PageLayout>
           <div className="createpage-create-main-section">
+            <div className="createpage-create-project-title">
+              <h2>{type === "funding" ? "펀딩 작성하기" : "동행 작성하기"}</h2>
+            </div>
             <form
               className="createpage-create-project-form"
               onSubmit={handleSubmit}
@@ -338,7 +379,7 @@ const CreatePageLayout = ({ children, type: initialType }) => {
                   <input
                     type="text"
                     value={hashtag}
-                    onChange={(e) => setHashtag(e.target.value)}
+                    onChange={handleHashtagChange}
                     onKeyPress={handleHashtagKeyPress} //해시태그 추가 핸들러
                     maxLength="15"
                   />
@@ -510,7 +551,7 @@ const CreatePageLayout = ({ children, type: initialType }) => {
 
               <div className="createpage-form-group createpage-recruitment-group-wrap">
                 <label>
-                  프로젝트 설정
+                  목표 설정
                   <span className="createpage-form-required-check"> *</span>
                 </label>
                 <div className="createpage-form-group createpage-recruitment-group">
@@ -589,9 +630,7 @@ const CreatePageLayout = ({ children, type: initialType }) => {
               </div>
 
               <button type="submit" className="createpage-submit-button">
-                <span>
-                  {projectId ? "프로젝트 수정하기" : "프로젝트 등록하기"}
-                </span>
+                <span>{projectId ? "수정하기" : "등록하기"}</span>
               </button>
             </form>
             {children}

--- a/frontend/src/views/ProjectDetailPage/ProjectDetailPageWith.js
+++ b/frontend/src/views/ProjectDetailPage/ProjectDetailPageWith.js
@@ -74,7 +74,7 @@ const ProjectDetailPageWith = ({ hashtags }) => {
     navigate(`/projects/${projectId}/edit`);
   };
 
-  const formatDate = date => {
+  const formatDate = (date) => {
     return new Date(date).toLocaleDateString("ko-KR", {
       year: "numeric",
       month: "2-digit",
@@ -83,9 +83,9 @@ const ProjectDetailPageWith = ({ hashtags }) => {
   };
 
   // 가격에 쉼표를 추가하는 함수
-  const formatPrice = price => {
-    return price.toString().replace(/\B(?=(\d{3})+(?!\d))/g, ",");
-  };
+  // const formatPrice = (price) => {
+  //   return price.toString().replace(/\B(?=(\d{3})+(?!\d))/g, ",");
+  // };
 
   if (!project) {
     return <div>Loading...</div>;
@@ -126,7 +126,7 @@ const ProjectDetailPageWith = ({ hashtags }) => {
                 </div>
                 <div className="ProjectDetailPage-option">
                   <div className="ProjectDetailPage-detail-title">
-                    옵션 선택 <span>*</span>
+                    옵션 선택 <span></span>
                   </div>
                   <div className="ProjectDetailPage-option-goods">
                     <div className="ProjectDetailPage-goods-list">
@@ -137,7 +137,7 @@ const ProjectDetailPageWith = ({ hashtags }) => {
                         >
                           <div className="ProjectDetailPage-goods">
                             {index + 1}. {option.name}{" "}
-                            <span>({formatPrice(option.price)}원/1개)</span>
+                            {/* <span>({formatPrice(option.price)}원/1개)</span> */}
                           </div>
                           <div className="ProjectDetailPage-input">
                             <input type="checkbox" name="optionCount" />


### PR DESCRIPTION
## 📌 fix: CreatePage and ProjectPage (#486)

### ➡️PR 방향

- [ ] 버그 -> 버그 스크린 샷 첨부 요망
- [ ] 수정 -> 원본, 바뀐 부분 첨부, 설명 요망
- [ ] 초기(첫 푸시) -> 첫 푸시 내용 설명 요망
- [ ] 요청 -> 요청 부분 설명 요망

### 📝내용

- 펀딩/동행 작성시 글제목 위에 타이틀 추가
- 타이틀 추가하며 세부 css 수정 
- 동행 옵션: 가격란 생략
- 등록하기 버튼: 프로젝트 생략
- 해시태그 1: 10개 입력됐을 때 modal로 안내
- 해시태그 2: 해시태그명 뒤에 띄워쓰기 눌렀을 때 중복으로 등록이 되는 현상 고침
- 옵션 추가: _펀딩_ 옵션 추가시 가격을 적지 않아도 등록이 되는 현상 고침 
- 옵션 추가: 최대 10개로 한정

---

#### ⛓️연결된 이슈 :

Fixes #486 
